### PR TITLE
props をtypescriptで型付けする。vueにfontawesome(5)を導入する

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7,6 +7,11 @@
     "": {
       "version": "0.1.0",
       "dependencies": {
+        "@fortawesome/fontawesome-svg-core": "^1.2.36",
+        "@fortawesome/free-brands-svg-icons": "^5.15.4",
+        "@fortawesome/free-regular-svg-icons": "^5.15.4",
+        "@fortawesome/free-solid-svg-icons": "^5.15.4",
+        "@fortawesome/vue-fontawesome": "^3.0.0-5",
         "core-js": "^3.6.5",
         "vue": "^3.0.0"
       },
@@ -1643,6 +1648,72 @@
       },
       "engines": {
         "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@fortawesome/fontawesome-common-types": {
+      "version": "0.2.36",
+      "resolved": "https://registry.npmjs.org/@fortawesome/fontawesome-common-types/-/fontawesome-common-types-0.2.36.tgz",
+      "integrity": "sha512-a/7BiSgobHAgBWeN7N0w+lAhInrGxksn13uK7231n2m8EDPE3BMCl9NZLTGrj9ZXfCmC6LM0QLqXidIizVQ6yg==",
+      "hasInstallScript": true,
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/@fortawesome/fontawesome-svg-core": {
+      "version": "1.2.36",
+      "resolved": "https://registry.npmjs.org/@fortawesome/fontawesome-svg-core/-/fontawesome-svg-core-1.2.36.tgz",
+      "integrity": "sha512-YUcsLQKYb6DmaJjIHdDWpBIGCcyE/W+p/LMGvjQem55Mm2XWVAP5kWTMKWLv9lwpCVjpLxPyOMOyUocP1GxrtA==",
+      "hasInstallScript": true,
+      "dependencies": {
+        "@fortawesome/fontawesome-common-types": "^0.2.36"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/@fortawesome/free-brands-svg-icons": {
+      "version": "5.15.4",
+      "resolved": "https://registry.npmjs.org/@fortawesome/free-brands-svg-icons/-/free-brands-svg-icons-5.15.4.tgz",
+      "integrity": "sha512-f1witbwycL9cTENJegcmcZRYyawAFbm8+c6IirLmwbbpqz46wyjbQYLuxOc7weXFXfB7QR8/Vd2u5R3q6JYD9g==",
+      "hasInstallScript": true,
+      "dependencies": {
+        "@fortawesome/fontawesome-common-types": "^0.2.36"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/@fortawesome/free-regular-svg-icons": {
+      "version": "5.15.4",
+      "resolved": "https://registry.npmjs.org/@fortawesome/free-regular-svg-icons/-/free-regular-svg-icons-5.15.4.tgz",
+      "integrity": "sha512-9VNNnU3CXHy9XednJ3wzQp6SwNwT3XaM26oS4Rp391GsxVYA+0oDR2J194YCIWf7jNRCYKjUCOduxdceLrx+xw==",
+      "hasInstallScript": true,
+      "dependencies": {
+        "@fortawesome/fontawesome-common-types": "^0.2.36"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/@fortawesome/free-solid-svg-icons": {
+      "version": "5.15.4",
+      "resolved": "https://registry.npmjs.org/@fortawesome/free-solid-svg-icons/-/free-solid-svg-icons-5.15.4.tgz",
+      "integrity": "sha512-JLmQfz6tdtwxoihXLg6lT78BorrFyCf59SAwBM6qV/0zXyVeDygJVb3fk+j5Qat+Yvcxp1buLTY5iDh1ZSAQ8w==",
+      "hasInstallScript": true,
+      "dependencies": {
+        "@fortawesome/fontawesome-common-types": "^0.2.36"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/@fortawesome/vue-fontawesome": {
+      "version": "3.0.0-5",
+      "resolved": "https://registry.npmjs.org/@fortawesome/vue-fontawesome/-/vue-fontawesome-3.0.0-5.tgz",
+      "integrity": "sha512-aNmBT4bOecrFsZTog1l6AJDQHPP3ocXV+WQ3Ogy8WZCqstB/ahfhH4CPu5i4N9Hw0MBKXqE+LX+NbUxcj8cVTw==",
+      "peerDependencies": {
+        "@fortawesome/fontawesome-svg-core": "~1 || >=1.3.0-beta1",
+        "vue": ">= 3.0.0 < 4"
       }
     },
     "node_modules/@hapi/address": {
@@ -17799,6 +17870,49 @@
         "@babel/helper-validator-identifier": "^7.15.7",
         "to-fast-properties": "^2.0.0"
       }
+    },
+    "@fortawesome/fontawesome-common-types": {
+      "version": "0.2.36",
+      "resolved": "https://registry.npmjs.org/@fortawesome/fontawesome-common-types/-/fontawesome-common-types-0.2.36.tgz",
+      "integrity": "sha512-a/7BiSgobHAgBWeN7N0w+lAhInrGxksn13uK7231n2m8EDPE3BMCl9NZLTGrj9ZXfCmC6LM0QLqXidIizVQ6yg=="
+    },
+    "@fortawesome/fontawesome-svg-core": {
+      "version": "1.2.36",
+      "resolved": "https://registry.npmjs.org/@fortawesome/fontawesome-svg-core/-/fontawesome-svg-core-1.2.36.tgz",
+      "integrity": "sha512-YUcsLQKYb6DmaJjIHdDWpBIGCcyE/W+p/LMGvjQem55Mm2XWVAP5kWTMKWLv9lwpCVjpLxPyOMOyUocP1GxrtA==",
+      "requires": {
+        "@fortawesome/fontawesome-common-types": "^0.2.36"
+      }
+    },
+    "@fortawesome/free-brands-svg-icons": {
+      "version": "5.15.4",
+      "resolved": "https://registry.npmjs.org/@fortawesome/free-brands-svg-icons/-/free-brands-svg-icons-5.15.4.tgz",
+      "integrity": "sha512-f1witbwycL9cTENJegcmcZRYyawAFbm8+c6IirLmwbbpqz46wyjbQYLuxOc7weXFXfB7QR8/Vd2u5R3q6JYD9g==",
+      "requires": {
+        "@fortawesome/fontawesome-common-types": "^0.2.36"
+      }
+    },
+    "@fortawesome/free-regular-svg-icons": {
+      "version": "5.15.4",
+      "resolved": "https://registry.npmjs.org/@fortawesome/free-regular-svg-icons/-/free-regular-svg-icons-5.15.4.tgz",
+      "integrity": "sha512-9VNNnU3CXHy9XednJ3wzQp6SwNwT3XaM26oS4Rp391GsxVYA+0oDR2J194YCIWf7jNRCYKjUCOduxdceLrx+xw==",
+      "requires": {
+        "@fortawesome/fontawesome-common-types": "^0.2.36"
+      }
+    },
+    "@fortawesome/free-solid-svg-icons": {
+      "version": "5.15.4",
+      "resolved": "https://registry.npmjs.org/@fortawesome/free-solid-svg-icons/-/free-solid-svg-icons-5.15.4.tgz",
+      "integrity": "sha512-JLmQfz6tdtwxoihXLg6lT78BorrFyCf59SAwBM6qV/0zXyVeDygJVb3fk+j5Qat+Yvcxp1buLTY5iDh1ZSAQ8w==",
+      "requires": {
+        "@fortawesome/fontawesome-common-types": "^0.2.36"
+      }
+    },
+    "@fortawesome/vue-fontawesome": {
+      "version": "3.0.0-5",
+      "resolved": "https://registry.npmjs.org/@fortawesome/vue-fontawesome/-/vue-fontawesome-3.0.0-5.tgz",
+      "integrity": "sha512-aNmBT4bOecrFsZTog1l6AJDQHPP3ocXV+WQ3Ogy8WZCqstB/ahfhH4CPu5i4N9Hw0MBKXqE+LX+NbUxcj8cVTw==",
+      "requires": {}
     },
     "@hapi/address": {
       "version": "2.1.4",

--- a/package.json
+++ b/package.json
@@ -8,6 +8,11 @@
     "lint": "vue-cli-service lint"
   },
   "dependencies": {
+    "@fortawesome/fontawesome-svg-core": "^1.2.36",
+    "@fortawesome/free-brands-svg-icons": "^5.15.4",
+    "@fortawesome/free-regular-svg-icons": "^5.15.4",
+    "@fortawesome/free-solid-svg-icons": "^5.15.4",
+    "@fortawesome/vue-fontawesome": "^3.0.0-5",
     "core-js": "^3.6.5",
     "vue": "^3.0.0"
   },

--- a/src/App.vue
+++ b/src/App.vue
@@ -1,5 +1,17 @@
 <template>
   <div class="app">
+    <p style="text-align: center; margin-bottom: 0">
+      <a
+        id="github-link"
+        href="https://github.com/toshi-ue/vue_with_typescript"
+        target="_blank"
+        rel="noopener noreferrer"
+      >
+        <font-awesome-icon :icon="['fab', 'github']" size="2x" />
+        <span class="github-content"> GitHub Repository </span>
+        <font-awesome-icon :icon="['fa', 'external-link-alt']" size="xs" />
+      </a>
+    </p>
     <JobList :jobs="jobs" />
   </div>
 </template>
@@ -47,4 +59,11 @@ export default defineComponent({
 </script>
 
 <style>
+#github-link {
+  color: black;
+  text-decoration: none;
+}
+.github-content {
+  font-size: 1.3rem;
+}
 </style>

--- a/src/App.vue
+++ b/src/App.vue
@@ -1,16 +1,17 @@
 <template>
   <div class="app">
-    <p>{{ jobs[0].location }}</p>
+    <JobList :jobs="jobs" />
   </div>
 </template>
 
 <script lang="ts">
 import { defineComponent, reactive, ref, toRefs } from "vue";
 import Job from "./types/job";
+import JobList from "./components/JobList.vue";
 
 export default defineComponent({
   name: "App",
-  components: {},
+  components: { JobList },
   setup() {
     const jobs = ref<Job[]>([
       {

--- a/src/components/JobList.vue
+++ b/src/components/JobList.vue
@@ -1,0 +1,67 @@
+<template>
+  <div class="job-list">
+    <ul>
+      <li v-for="job in jobs" :key="job.id">
+        <h2>{{ job.title }} in {{ job.location }}</h2>
+        <div class="salary">
+          <p>{{ job.salary }} rupees</p>
+        </div>
+        <div class="description">
+          <p>
+            Lorem ipsum dolor, sit amet consectetur adipisicing elit. Inventore
+            dolor consectetur voluptatem deserunt dolores autem, blanditiis ut
+            enim id molestias distinctio similique harum, mollitia iusto placeat
+            maiores ad a? Cupiditate.
+          </p>
+        </div>
+      </li>
+    </ul>
+  </div>
+</template>
+
+<script lang="ts">
+import { defineComponent, PropType } from "vue";
+import Job from "@/types/job";
+
+export default defineComponent({
+  // props: ['jobs']
+  props: {
+    jobs: {
+      required: true,
+      type: Array as PropType<Job[]>,
+    },
+  },
+});
+</script>
+
+<style scoped>
+.job-list {
+  max-width: 960px;
+  margin: 40px auto;
+}
+.job-list ul {
+  padding: 0;
+}
+.job-list li {
+  list-style-type: none;
+  background: white;
+  padding: 16px;
+  margin: 16px 0;
+  border-radius: 4px;
+}
+.job-list h2 {
+  margin: 0 0 10px;
+  text-transform: capitalize;
+}
+.salary {
+  display: flex;
+}
+.salary img {
+  width: 30px;
+}
+.salary p {
+  color: #17bf66;
+  font-weight: bold;
+  margin: 10px 4px;
+}
+</style>

--- a/src/components/JobList.vue
+++ b/src/components/JobList.vue
@@ -37,7 +37,7 @@ export default defineComponent({
 <style scoped>
 .job-list {
   max-width: 960px;
-  margin: 40px auto;
+  margin: 16px auto;
 }
 .job-list ul {
   padding: 0;

--- a/src/main.ts
+++ b/src/main.ts
@@ -2,4 +2,12 @@ import { createApp } from 'vue'
 import App from './App.vue'
 import "./assets/global.css";
 
-createApp(App).mount('#app')
+import { library } from '@fortawesome/fontawesome-svg-core'
+
+import { faExternalLinkAlt } from "@fortawesome/free-solid-svg-icons";
+import { faGithub } from '@fortawesome/free-brands-svg-icons'
+import { FontAwesomeIcon } from '@fortawesome/vue-fontawesome'
+
+library.add(faExternalLinkAlt, faGithub)
+
+createApp(App).component("font-awesome-icon", FontAwesomeIcon).mount('#app')


### PR DESCRIPTION
PropsをTypeScriptで定義する方法をメモ。

Vueでfontawesomeを使う方法も記述。
[Vue.js で FontAwesome を使う方法 - to-me-mo-rrow - 未来の自分に残すメモ -](https://r17n.page/2019/10/14/vue-with-fontawesome/)
[Vue.jsでFontAwesomeを使う方法(brands) - Qiita](https://qiita.com/kanahashimoto03/items/40ab5135ea315e04f838)

ちなみにこんなのもあるらしい。かなり使えそう。
[vue-fa - Tiny FontAwesome 5 component for Vue.js](https://cweili.github.io/vue-fa/)